### PR TITLE
Fix : PlayerMovement 에서 마스터 클라이언트가 아닌 경우에도 아이템의 Use() 메서드를 실행

### DIFF
--- a/Zomble/Assets/02.Scripts/PlayerMovement.cs
+++ b/Zomble/Assets/02.Scripts/PlayerMovement.cs
@@ -58,13 +58,4 @@ public class PlayerMovement : MonoBehaviourPun
             playerRigidbody.rotation * 
             Quaternion.Euler(0, turn, 0);
     }
-
-    private void OnTriggerEnter(Collider other)
-    {
-        IItem item = other.GetComponent<IItem>();
-        if(item != null)
-        {
-            item.Use(gameObject);
-        }
-    }
 }


### PR DESCRIPTION
* PlayerMovement의 OnTriggerEnter에서 일어나는 Failed to 'network-remove' GameObject 예외를 해결
* PlayerHealth 와 중복되는 아이템 사용 처리를 제거